### PR TITLE
Add lightweight StatsLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,21 @@ very simple API:
 ...
 ```
 
+For lower overhead you can use ``StatsLite`` which keeps only the
+core moments:
 
-The following properties are accesible on a Stats object: n, min, max, variance, skewness, and kurtosis.
-In addition, a Stats object tracks percentiles.
+```python
+>>> lite = faststat.StatsLite()
+>>> lite.add(point)
+```
+
+
+The following properties are accessible on a ``Stats`` object: ``n``, ``min``,
+``max``, variance, skewness and kurtosis.  It also tracks percentiles and other
+optional features.
+
+``StatsLite`` exposes the same basic properties without the percentile or
+window-tracking overhead.
 
 Performance is pretty good: 0.63 microseconds per point on my machine.  (Provided the C module is available.)
 

--- a/faststat/faststat.py
+++ b/faststat/faststat.py
@@ -168,6 +168,48 @@ class Stats(_BaseStats):
             return getattr(self._stats, name)
 
 
+class StatsLite(object):
+    '''
+    Lightweight statistics class tracking only counts and moments.
+    '''
+    def __init__(self):
+        self._stats = _faststat.StatsLite()
+        self.add = self._stats.add
+
+    def __getattr__(self, name):
+        return getattr(self._stats, name)
+
+    @property
+    def variance(self):
+        if self.n < 2:
+            return float('nan')
+        return self.m2 / (self.n - 1)
+
+    @property
+    def skewness(self):
+        if not self.m2:
+            return float('nan')
+        return self.n ** 0.5 * self.m3 / self.m2 ** 1.5
+
+    @property
+    def kurtosis(self):
+        if not self.m2:
+            return float('nan')
+        return self.n * self.m4 / self.m2 ** 2 - 3
+
+    @property
+    def geometric_mean(self):
+        return math.exp(self.sum_of_logs / self.n)
+
+    @property
+    def harmonic_mean(self):
+        return self.n / self.sum_of_inv
+
+    def __repr__(self):
+        return '<faststat.StatsLite n={0} mean={1}>'.format(
+            self.n, _sigfigs(self.mean))
+
+
 class _TimeStats(_BaseStats):
     def get_percentiles(self):
         data = self._stats.get_percentiles()


### PR DESCRIPTION
## Summary
- introduce `StatsLite` as a small moment-tracking struct
- refactor heavyweight `Stats` to reuse `StatsLite`
- update the Python extension to follow the same pattern

## Testing
- `cargo build` in `faststat-core`
- `cargo build` in `faststat-rs`
- `pip install -e .`
- `python` sanity check of `StatsLite`

------
https://chatgpt.com/codex/tasks/task_e_6880fc71f474832983dbd2432712a294